### PR TITLE
gitea: update to v1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - **nextcloud:** if you changed [`nextcloud_apps`](https://gitlab.com/nodiscc/xsrv/-/blob/master/roles/nextcloud/defaults/main.yml) from its default value, remove `files_videoplayer` from the list (`xsrv edit-host/edit-group`)
 - **jitsi:** set [`jitsi_prosody_password`](https://gitlab.com/nodiscc/xsrv/-/blob/master/roles/jitsi/defaults/main.yml) in your host configuration variables (`xsrv edit-vault`)
 - **rss_bridge:** if you are using the [`rss_bridge`](https://gitlab.com/nodiscc/xsrv/-/tree/1.10.0/roles/rss_bridge) role, update `requirements.yml` (`xsrv edit-requirements`) and `playbook.yml` ([`xsrv edit-playbook`](https://xsrv.readthedocs.io/en/latest/usage.html#xsrv-edit-playbook)) to use the archived [`nodiscc.toolbox.rss_bridge`](https://gitlab.com/nodiscc/toolbox/-/tree/master/ARCHIVE/ANSIBLE-COLLECTION) role instead. The primary goal for the RSS-Bridge role was to provide RSS feeds for Twitter accounts. Thins can be done by using https://nitter.net/ACCOUNT/rss instead (or one of the [public Nitter instances](https://github.com/zedeus/nitter/wiki/Instances)).
+- **gitea:** if `gitea_mailer_enabled` is set to `yes`, add the new [`gitea_mail_protocol/gitea_mail_port`](https://gitlab.com/nodiscc/xsrv/-/blob/master/roles/gitea/defaults/main.yml) settings to your host configuration.
 
 **Added:**
 - netdata: needrestart: add an option to reboot the OS periodically if needed after Linux kernel upgrades ([`needrestart_autorestart_cron`](https://gitlab.com/nodiscc/xsrv/-/blob/master/roles/monitoring_netdata/defaults/main.yml))
@@ -28,7 +29,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - monitoring_utils: lynis: only report warnings by default, not suggestion or manual checklist items ([`lynis_report_regex`](https://gitlab.com/nodiscc/xsrv/-/blob/master/roles/monitoring_utils/defaults/main.yml))
 - common: ensure `/var/log/wtmp` does not become world-readable again after log rotation
 - nextcloud: upgrade to v25.0.2 [[1]](https://nextcloud.com/blog/announcing-nextcloud-hub-3-brand-new-design-and-photos-2-0-with-editor-and-ai/) [[2]](https://nextcloud.com/changelog/#latest25)
-- gitea: update to [v1.17.4](https://github.com/go-gitea/gitea/releases/tag/v1.17.4)
+- gitea: update to v1.18.0 [[1]](https://github.com/go-gitea/gitea/releases/tag/v1.17.4) [[2]](https://github.com/go-gitea/gitea/releases/tag/v1.18.0)
 - openldap: update ldap-account-manager to [v8.2](https://github.com/LDAPAccountManager/lam/releases/tag/lam_8_2)
 - xsrv: update ansible to [v7.1.0](https://github.com/ansible-community/ansible-build-data/blob/main/7/CHANGELOG-v7.rst)
 - update ansible tags (see `xsrv help-tags`)

--- a/roles/gitea/defaults/main.yml
+++ b/roles/gitea/defaults/main.yml
@@ -88,25 +88,9 @@ gitea_mailer_enabled: no
 
 # gitea_mail_user: "CHANGEME"
 # gitea_mail_password: "CHANGEME"
-
-# New in 1.18.0 :
-
-# Mail server protocol. One of "smtp", "smtps", "smtp+starttls", "smtp+unix", "sendmail", "dummy".
-# - sendmail: use the operating system's `sendmail` command instead of SMTP. This is common on Linux systems.
-# - dummy: send email messages to the log as a testing phase.
-# If your provider does not explicitly say which protocol it uses but does provide a port,
-# you can set SMTP_PORT (gitea_mail_smtp_port) instead and this will be inferred.
-# gitea_mail_protocol: "CHANGEME"
-
 # Mail server address, e.g. smtp.gmail.com.
-# For smtp+unix, this should be a path to a unix socket instead.
-# (Before 1.18, see the notice, this was combined with SMTP_PORT as HOST.)
-# gitea_mail_smtp_addr: "CHANGEME"
-
-# Mail server port. Common ports are:
-#   25:  insecure SMTP
-#   465: SMTP Secure
-#   587: StartTLS
-# If no protocol is specified, it will be inferred by this setting.
-# (Before 1.18, this was combined with SMTP_ADDR as HOST.)
+# gitea_mail_host: "CHANGEME"
+# Mail server protocol (smtp/smtps/smtp+starttls/smtp+unix/sendmail/dummy)
+# gitea_mail_protocol: "CHANGEME"
+# Mail server port (e.g. 25/465/587)
 # gitea_mail_smtp_port: "CHANGEME"

--- a/roles/gitea/defaults/main.yml
+++ b/roles/gitea/defaults/main.yml
@@ -93,4 +93,4 @@ gitea_mailer_enabled: no
 # Mail server protocol (smtp/smtps/smtp+starttls/smtp+unix/sendmail/dummy)
 # gitea_mail_protocol: "CHANGEME"
 # Mail server port (e.g. 25/465/587)
-# gitea_mail_smtp_port: "CHANGEME"
+# gitea_mail_port: "CHANGEME"

--- a/roles/gitea/defaults/main.yml
+++ b/roles/gitea/defaults/main.yml
@@ -27,7 +27,7 @@ gitea_db_host: "/run/postgresql/" # /run/postgresql/ for a local postgresql data
 gitea_db_password: "{{ gitea_db_password }}" # leave empty for local postgresql database/peer authentication
 gitea_db_port: 5432 # usually 5432 for PostgreSQL, 3306 for MySQL
 # gitea version to install - https://github.com/go-gitea/gitea/releases.atom; remove leading v
-gitea_version: '1.17.4'
+gitea_version: '1.18.0'
 # HTTPS and SSL/TLS certificate mode for the gitea webserver virtualhost
 #   letsencrypt: acquire a certificate from letsencrypt.org
 #   selfsigned: generate a self-signed certificate
@@ -85,7 +85,28 @@ gitea_mailer_enabled: no
 # Mail settings below are required if gitea mailer is enabled
 # 'From' address used in mails sent by gitea
 # gitea_mail_from: "gitea-noreply@{{ gitea_fqdn }}"
-# SMTP host, username and password for outgoing mail from gitea
-# gitea_mail_host: "CHANGEME"
+
 # gitea_mail_user: "CHANGEME"
 # gitea_mail_password: "CHANGEME"
+
+# New in 1.18.0 :
+
+# Mail server protocol. One of "smtp", "smtps", "smtp+starttls", "smtp+unix", "sendmail", "dummy".
+# - sendmail: use the operating system's `sendmail` command instead of SMTP. This is common on Linux systems.
+# - dummy: send email messages to the log as a testing phase.
+# If your provider does not explicitly say which protocol it uses but does provide a port,
+# you can set SMTP_PORT (gitea_mail_smtp_port) instead and this will be inferred.
+# gitea_mail_protocol: "CHANGEME"
+
+# Mail server address, e.g. smtp.gmail.com.
+# For smtp+unix, this should be a path to a unix socket instead.
+# (Before 1.18, see the notice, this was combined with SMTP_PORT as HOST.)
+# gitea_mail_smtp_addr: "CHANGEME"
+
+# Mail server port. Common ports are:
+#   25:  insecure SMTP
+#   465: SMTP Secure
+#   587: StartTLS
+# If no protocol is specified, it will be inferred by this setting.
+# (Before 1.18, this was combined with SMTP_ADDR as HOST.)
+# gitea_mail_smtp_port: "CHANGEME"

--- a/roles/gitea/templates/etc_gitea_app.ini
+++ b/roles/gitea/templates/etc_gitea_app.ini
@@ -5,7 +5,6 @@
 ;; If you don't know what a setting is you should not set it.
 ;;
 ;; see https://docs.gitea.io/en-us/config-cheat-sheet/ for additional documentation.
-;; see https://raw.githubusercontent.com/go-gitea/gitea/master/custom/conf/app.example.ini for a list of all settings
 
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -13,7 +12,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; App name that shows in every page title
-APP_NAME = Gitea
+APP_NAME = Gitea; Git with a cup of tea
 ;;
 ;; RUN_USER will automatically detect the current user - but you can set it here change it if you run locally
 RUN_USER = gitea
@@ -30,11 +29,23 @@ RUN_MODE = prod
 ;; The protocol the server listens on. One of 'http', 'https', 'unix' or 'fcgi'. Defaults to 'http'
 ;PROTOCOL = http
 ;;
+;; Expect PROXY protocol headers on connections
+;USE_PROXY_PROTOCOL = false
+;;
+;; Use PROXY protocol in TLS Bridging mode
+;PROXY_PROTOCOL_TLS_BRIDGING = false
+;;
+; Timeout to wait for PROXY protocol header (set to 0 to have no timeout)
+;PROXY_PROTOCOL_HEADER_TIMEOUT=5s
+;;
+; Accept PROXY protocol headers with UNKNOWN type
+;PROXY_PROTOCOL_ACCEPT_UNKNOWN=false
+;;
 ;; Set the domain for the server
 ;DOMAIN = localhost
 ;;
 ;; Overwrite the automatically generated public URL. Necessary for proxies and docker.
-ROOT_URL = {{ gitea_root_url }}
+ROOT_URL = {{ gitea_root_url }};%(PROTOCOL)s://%(DOMAIN)s:%(HTTP_PORT)s/
 ;;
 ;; when STATIC_URL_PREFIX is empty it will follow ROOT_URL
 ;STATIC_URL_PREFIX =
@@ -52,6 +63,8 @@ HTTP_PORT = 3003
 ;REDIRECT_OTHER_PORT = false
 ;PORT_TO_REDIRECT = 80
 ;;
+;; expect PROXY protocol header on connections to https redirector.
+;REDIRECTOR_USE_PROXY_PROTOCOL = %(USE_PROXY_PROTOCOL)
 ;; Minimum and maximum supported TLS versions
 ;SSL_MIN_VERSION=TLSv1.2
 ;SSL_MAX_VERSION=
@@ -62,7 +75,7 @@ HTTP_PORT = 3003
 ;; SSL Cipher Suites
 ;SSL_CIPHER_SUITES=; Will default to "ecdhe_ecdsa_with_aes_256_gcm_sha384,ecdhe_rsa_with_aes_256_gcm_sha384,ecdhe_ecdsa_with_aes_128_gcm_sha256,ecdhe_rsa_with_aes_128_gcm_sha256,ecdhe_ecdsa_with_chacha20_poly1305,ecdhe_rsa_with_chacha20_poly1305" if aes is supported by hardware, otherwise chacha will be first.
 ;;
-;; Timeout for any write to the connection. (Set to 0 to disable all timeouts.)
+;; Timeout for any write to the connection. (Set to -1 to disable all timeouts.)
 ;PER_WRITE_TIMEOUT = 30s
 ;;
 ;; Timeout per Kb written to connections.
@@ -77,17 +90,23 @@ HTTP_PORT = 3003
 ;; Do not set this variable if PROTOCOL is set to 'unix'.
 ;LOCAL_ROOT_URL = %(PROTOCOL)s://%(HTTP_ADDR)s:%(HTTP_PORT)s/
 ;;
+;; When making local connections pass the PROXY protocol header.
+;LOCAL_USE_PROXY_PROTOCOL = %(USE_PROXY_PROTOCOL)
+;;
 ;; Disable SSH feature when not available
 ;DISABLE_SSH = false
 ;;
 ;; Whether to use the builtin SSH server or not.
 ;START_SSH_SERVER = false
 ;;
-;; Username to use for the builtin SSH server.
+;; Expect PROXY protocol header on connections to the built-in SSH server
+;SSH_SERVER_USE_PROXY_PROTOCOL = false
+;;
+;; Username to use for the builtin SSH server. If blank, then it is the value of RUN_USER.
 ;BUILTIN_SSH_SERVER_USER = %(RUN_USER)s
 ;;
 ;; Domain name to be exposed in clone URL
-SSH_DOMAIN = {{ gitea_fqdn }}
+SSH_DOMAIN = {{ gitea_fqdn }}; %(DOMAIN)s
 ;;
 ;; SSH username displayed in clone URLs.
 ;SSH_USER = %(BUILTIN_SSH_SERVER_USER)s
@@ -110,7 +129,7 @@ SSH_ROOT_PATH = {{ gitea_user_home }}/.ssh
 ;;
 ;; Gitea will create a authorized_keys file by default when it is not using the internal ssh server
 ;; If you intend to use the AuthorizedKeysCommand functionality then you should turn this off.
-SSH_CREATE_AUTHORIZED_KEYS_FILE = true
+;SSH_CREATE_AUTHORIZED_KEYS_FILE = true
 ;;
 ;; Gitea will create a authorized_principals file by default when it is not using the internal ssh server
 ;; If you intend to use the AuthorizedPrincipalsCommand functionality then you should turn this off.
@@ -122,7 +141,7 @@ SSH_CREATE_AUTHORIZED_KEYS_FILE = true
 ;;
 ;; For the built-in SSH server, choose the key exchange algorithms to support for SSH connections,
 ;; for system SSH this setting has no effect
-;SSH_SERVER_KEY_EXCHANGES = curve25519-sha256@libssh.org, ecdh-sha2-nistp256, ecdh-sha2-nistp384, ecdh-sha2-nistp521, diffie-hellman-group14-sha1
+;SSH_SERVER_KEY_EXCHANGES = curve25519-sha256, ecdh-sha2-nistp256, ecdh-sha2-nistp384, ecdh-sha2-nistp521, diffie-hellman-group14-sha256, diffie-hellman-group14-sha1
 ;;
 ;; For the built-in SSH server, choose the MACs to support for SSH connections,
 ;; for system SSH this setting has no effect
@@ -168,7 +187,7 @@ SSH_CREATE_AUTHORIZED_KEYS_FILE = true
 ;; Enable exposure of SSH clone URL to anonymous visitors, default is false
 ;SSH_EXPOSE_ANONYMOUS = false
 ;;
-;; Timeout for any write to ssh connections. (Set to 0 to disable all timeouts.)
+;; Timeout for any write to ssh connections. (Set to -1 to disable all timeouts.)
 ;; Will default to the PER_WRITE_TIMEOUT.
 ;SSH_PER_WRITE_TIMEOUT = 30s
 ;;
@@ -242,7 +261,7 @@ OFFLINE_MODE  = {{ gitea_offline_mode }}
 ;; PPROF_DATA_PATH, use an absolute path when you start gitea as service
 ;PPROF_DATA_PATH = data/tmp/pprof
 ;;
-;; Landing page, can be "home", "explore", "organizations" or "login"
+;; Landing page, can be "home", "explore", "organizations", "login", or any URL such as "/org/repo" or even "https://anotherwebsite.com"
 ;; The "login" choice is not a security measure but just a UI flow change, use REQUIRE_SIGNIN_VIEW to force users to log in.
 ;LANDING_PAGE = home
 ;;
@@ -329,14 +348,19 @@ LOG_SQL = false ; if unset defaults to true
 ;; Whether the installer is disabled (set to true to disable the installer)
 INSTALL_LOCK = true
 ;;
-;; Global secret key that will be used - if blank will be regenerated.
+;; Global secret key that will be used
+;; This key is VERY IMPORTANT. If you lose it, the data encrypted by it (like 2FA secret) can't be decrypted anymore.
 SECRET_KEY = {{ gitea_secret_key }}
+;;
+;; Alternative location to specify secret key, instead of this file; you cannot specify both this and SECRET_KEY, and must pick one
+;; This key is VERY IMPORTANT. If you lose it, the data encrypted by it (like 2FA secret) can't be decrypted anymore.
+;SECRET_KEY_URI = file:/etc/gitea/secret_key
 ;;
 ;; Secret used to validate communication within Gitea binary.
 INTERNAL_TOKEN = {{ gitea_internal_token }}
 ;;
-;; Instead of defining internal token in the configuration, this configuration option can be used to give Gitea a path to a file that contains the internal token (example value: file:/etc/gitea/internal_token)
-;INTERNAL_TOKEN_URI = ;e.g. /etc/gitea/internal_token
+;; Alternative location to specify internal token, instead of this file; you cannot specify both this and INTERNAL_TOKEN, and must pick one
+;INTERNAL_TOKEN_URI = file:/etc/gitea/internal_token
 ;;
 ;; How long to remember that a user is logged in before requiring relogin (in days)
 ;LOGIN_REMEMBER_DAYS = 7
@@ -347,9 +371,10 @@ INTERNAL_TOKEN = {{ gitea_internal_token }}
 ;; Name of cookie used to store authentication information.
 ;COOKIE_REMEMBER_NAME = gitea_incredible
 ;;
-;; Reverse proxy authentication header name of user name and email
+;; Reverse proxy authentication header name of user name, email, and full name
 ;REVERSE_PROXY_AUTHENTICATION_USER = X-WEBAUTH-USER
 ;REVERSE_PROXY_AUTHENTICATION_EMAIL = X-WEBAUTH-EMAIL
+;REVERSE_PROXY_AUTHENTICATION_FULL_NAME = X-WEBAUTH-FULLNAME
 ;;
 ;; Interpret X-Forwarded-For header or the X-Real-IP header and set this as the remote IP for the request
 ;REVERSE_PROXY_LIMIT = 1
@@ -369,6 +394,7 @@ MIN_PASSWORD_LENGTH = {{ gitea_min_password_length }}
 ;; By modifying the Gitea database, users can gain Gitea administrator privileges.
 ;; It also enables them to access other resources available to the user on the operating system that is running the Gitea instance and perform arbitrary actions in the name of the Gitea OS user.
 ;; WARNING: This maybe harmful to you website or your operating system.
+;; WARNING: Setting this to true does not change existing hooks in git repos; adjust it before if necessary.
 DISABLE_GIT_HOOKS = {{ 'false' if gitea_enable_git_hooks else 'true' }}
 ;;
 ;; Set to true to disable webhooks feature.
@@ -394,6 +420,23 @@ PASSWORD_COMPLEXITY = {{ gitea_password_complexity }}
 ;; Cache successful token hashes. API tokens are stored in the DB as pbkdf2 hashes however, this means that there is a potentially significant hashing load when there are multiple API operations.
 ;; This cache will store the successfully hashed tokens in a LRU cache as a balance between performance and security.
 ;SUCCESSFUL_TOKENS_CACHE_SIZE = 20
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+[camo]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; At the moment we only support images
+;;
+;; if the camo is enabled
+;ENABLED = false
+;; url to a camo image proxy, it **is required** if camo is enabled.
+;SERVER_URL =
+;; HMAC to encode urls with, it **is required** if camo is enabled.
+;HMAC_KEY =
+;; Set to true to use camo for https too lese only non https urls are proxyed
+;ALLWAYS = false
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -427,20 +470,6 @@ JWT_SECRET = {{ gitea_oauth2_jwt_secret }}
 ;;
 ;; Maximum length of oauth2 token/cookie stored on server
 ;MAX_TOKEN_LENGTH = 32767
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-[U2F]
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;
-;; NOTE: THE DEFAULT VALUES HERE WILL NEED TO BE CHANGED
-;; Two Factor authentication with security keys
-;; https://developers.yubico.com/U2F/App_ID.html
-;;
-;; DEPRECATED - this only applies to previously registered security keys using the U2F standard
-APP_ID = ; e.g. http://localhost:3000/
-
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -570,7 +599,10 @@ ENABLE_ACCESS_LOG = true
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; The path of git executable. If empty, Gitea searches through the PATH environment.
-PATH =
+;PATH =
+;;
+;; The HOME directory for Git
+;HOME_PATH = %(APP_DATA_PATH)/home
 ;;
 ;; Disables highlight of added and removed changes
 ;DISABLE_DIFF_HIGHLIGHT = false
@@ -595,6 +627,7 @@ PATH =
 ;GC_ARGS =
 ;;
 ;; If use git wire protocol version 2 when git version >= 2.18, default is true, set to false when you always want git wire protocol version 1
+;; To enable this for Git over SSH when using a OpenSSH server, add `AcceptEnv GIT_PROTOCOL` to your sshd_config file.
 ;ENABLE_AUTO_GIT_WIRE_PROTOCOL = true
 ;;
 ;; Respond to pushes to a non-default branch with a URL for creating a Pull Request (if the repository has them enabled)
@@ -656,13 +689,16 @@ ENABLE_NOTIFY_MAIL = true
 ;ENABLE_REVERSE_PROXY_AUTHENTICATION = false
 ;ENABLE_REVERSE_PROXY_AUTO_REGISTRATION = false
 ;ENABLE_REVERSE_PROXY_EMAIL = false
+;ENABLE_REVERSE_PROXY_FULL_NAME = false
 ;;
 ;; Enable captcha validation for registration
 ;ENABLE_CAPTCHA = false
 ;;
-;; Type of captcha you want to use. Options: image, recaptcha, hcaptcha
+;; Type of captcha you want to use. Options: image, recaptcha, hcaptcha, mcaptcha.
 ;CAPTCHA_TYPE = image
 ;;
+;; Change this to use recaptcha.net or other recaptcha service
+;RECAPTCHA_URL = https://www.google.com/recaptcha/
 ;; Enable recaptcha to use Google's recaptcha service
 ;; Go to https://www.google.com/recaptcha/admin to sign up for a key
 ;RECAPTCHA_SECRET =
@@ -672,8 +708,13 @@ ENABLE_NOTIFY_MAIL = true
 ;HCAPTCHA_SECRET =
 ;HCAPTCHA_SITEKEY =
 ;;
-;; Change this to use recaptcha.net or other recaptcha service
-;RECAPTCHA_URL = https://www.google.com/recaptcha/
+;; Change this to use demo.mcaptcha.org or your self-hosted mcaptcha.org instance.
+;MCAPTCHA_URL = https://demo.mcaptcha.org
+;;
+;; Go to your configured mCaptcha instance and register a sitekey
+;; and use your account's secret.
+;MCAPTCHA_SECRET =
+;MCAPTCHA_SITEKEY =
 ;;
 ;; Default value for KeepEmailPrivate
 ;; Each new user will get the value of this setting copied into their profile
@@ -737,7 +778,7 @@ NO_REPLY_ADDRESS = noreply.{{ gitea_fqdn }}
 ;SHOW_REGISTRATION_BUTTON = true
 ;;
 ;; Show milestones dashboard page - a view of all the user's milestones
-SHOW_MILESTONES_DASHBOARD_PAGE = true
+;SHOW_MILESTONES_DASHBOARD_PAGE = true
 ;;
 ;; Default value for AutoWatchNewRepos
 ;; When adding a repo to a team or creating a new repo all team members will watch the
@@ -766,7 +807,8 @@ SHOW_MILESTONES_DASHBOARD_PAGE = true
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 [repository]
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Root path for storing all repository data. It must be an absolute path. By default, it is stored in a sub-directory of `APP_DATA_PATH`.
+;; Root path for storing all repository data. By default, it is set to %(APP_DATA_PATH)/gitea-repositories.
+;; A relative path is interpreted as %(GITEA_WORK_DIR)/%(ROOT)
 ROOT = {{ gitea_user_home }}/repos/
 ;;
 ;; The script type this server supports. Usually this is `bash`, but some users report that only `sh` is available.
@@ -782,16 +824,16 @@ ROOT = {{ gitea_user_home }}/repos/
 ;ANSI_CHARSET =
 ;;
 ;; Force every new repository to be private
-FORCE_PRIVATE = {{ gitea_force_private }}
+;FORCE_PRIVATE = false
 ;;
 ;; Default privacy setting when creating a new repository, allowed values: last, private, public. Default is last which means the last setting used.
-DEFAULT_PRIVATE = {{ gitea_default_private }}
+;DEFAULT_PRIVATE = last
 ;;
 ;; Default private when using push-to-create
 ;DEFAULT_PUSH_CREATE_PRIVATE = true
 ;;
 ;; Global limit of repositories per user, applied at creation time. -1 means no limit
-MAX_CREATION_LIMIT = {{ gitea_user_repo_limit }}
+;MAX_CREATION_LIMIT = -1
 ;;
 ;; Mirror sync queue length, increase if mirror syncing starts hanging (DEPRECATED: please use [queue.mirror] LENGTH instead)
 ;MIRROR_QUEUE_LENGTH = 1000
@@ -814,7 +856,7 @@ MAX_CREATION_LIMIT = {{ gitea_user_repo_limit }}
 ;USE_COMPAT_SSH_URI = false
 ;;
 ;; Close issues as long as a commit on any branch marks it as fixed
-;; Comma separated list of globally disabled repo units. Allowed values: repo.issues, repo.ext_issues, repo.pulls, repo.wiki, repo.ext_wiki
+;; Comma separated list of globally disabled repo units. Allowed values: repo.issues, repo.ext_issues, repo.pulls, repo.wiki, repo.ext_wiki, repo.projects
 ;DISABLED_REPO_UNITS =
 ;;
 ;; Comma separated list of default repo units. Allowed values: repo.code, repo.releases, repo.issues, repo.pulls, repo.wiki, repo.projects.
@@ -833,13 +875,16 @@ MAX_CREATION_LIMIT = {{ gitea_user_repo_limit }}
 ;DISABLE_STARS = false
 ;;
 ;; The default branch name of new repositories
-DEFAULT_BRANCH = master
+;DEFAULT_BRANCH = main
 ;;
 ;; Allow adoption of unadopted repositories
 ;ALLOW_ADOPTION_OF_UNADOPTED_REPOSITORIES = false
 ;;
 ;; Allow deletion of unadopted repositories
 ;ALLOW_DELETION_OF_UNADOPTED_REPOSITORIES = false
+
+;; Don't allow download source archive files from UI
+;DISABLE_DOWNLOAD_SOURCE_ARCHIVES = false
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -861,7 +906,7 @@ DEFAULT_BRANCH = master
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
-;; Path for local repository copy. Defaults to `tmp/local-repo`
+;; Path for local repository copy. Defaults to `tmp/local-repo` (content gets deleted on gitea restart)
 ;LOCAL_COPY_PATH = tmp/local-repo
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -873,7 +918,7 @@ DEFAULT_BRANCH = master
 ;; Whether repository file uploads are enabled. Defaults to `true`
 ;ENABLED = true
 ;;
-;; Path for uploads. Defaults to `data/tmp/uploads` (tmp gets deleted on gitea restart)
+;; Path for uploads. Defaults to `data/tmp/uploads` (content gets deleted on gitea restart)
 ;TEMP_PATH = data/tmp/uploads
 ;;
 ;; Comma-separated list of allowed file extensions (`.zip`), mime types (`text/plain`) or wildcard type (`image/*`, `audio/*`, `video/*`). Empty value or `*/*` allows all types.
@@ -887,11 +932,11 @@ DEFAULT_BRANCH = master
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-[repository.pull-request]
+;[repository.pull-request]
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
-;; List of prefixes used in Pull Request title to mark them as Work In Progress
+;; List of prefixes used in Pull Request title to mark them as Work In Progress (matched in a case-insensitive manner)
 ;WORK_IN_PROGRESS_PREFIXES = WIP:,[WIP]
 ;;
 ;; List of keywords used in Pull Request comments to automatically close a related issue
@@ -899,6 +944,9 @@ DEFAULT_BRANCH = master
 ;;
 ;; List of keywords used in Pull Request comments to automatically reopen a related issue
 ;REOPEN_KEYWORDS = reopen,reopens,reopened
+;;
+;; Set default merge style for repository creating, valid options: merge, rebase, rebase-merge, squash
+;DEFAULT_MERGE_STYLE = merge
 ;;
 ;; In the default merge message for squash commits include at most this many commits
 ;DEFAULT_MERGE_MESSAGE_COMMITS_LIMIT = 50
@@ -917,6 +965,9 @@ DEFAULT_BRANCH = master
 ;;
 ;; Add co-authored-by and co-committed-by trailers if committer does not match author
 ;ADD_CO_COMMITTER_TRAILERS = true
+;;
+;; In addition to testing patches using the three-way merge method, re-test conflicting patches with git apply
+;TEST_CONFLICTING_PATCHES_WITH_GIT_APPLY = true
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1046,6 +1097,9 @@ ISSUE_PAGING_NUM = {{ gitea_issue_paging_num }}
 ;; Number of items that are displayed in home feed
 ;FEED_PAGING_NUM = 20
 ;;
+;; Number of items that are displayed in a single subsitemap
+;SITEMAP_PAGING_NUM = 20
+;;
 ;; Number of maximum commits displayed in commit graph.
 ;GRAPH_MAX_COMMIT_NUM = 100
 ;;
@@ -1064,7 +1118,7 @@ ISSUE_PAGING_NUM = {{ gitea_issue_paging_num }}
 SHOW_USER_EMAIL = {{ gitea_show_user_email }}
 ;;
 ;; Set the default theme for the Gitea install
-DEFAULT_THEME = gitea
+;DEFAULT_THEME = auto
 ;;
 ;; All available themes. Allow users select personalized themes regardless of the value of `DEFAULT_THEME`.
 ;THEMES = auto,gitea,arc-green
@@ -1086,7 +1140,11 @@ DEFAULT_THEME = gitea
 ;SEARCH_REPO_DESCRIPTION = true
 ;;
 ;; Whether to enable a Service Worker to cache frontend assets
-;USE_SERVICE_WORKER = true
+;USE_SERVICE_WORKER = false
+;;
+;; Whether to only show relevant repos on the explore page when no keyword is specified and default sorting is used.
+;; A repo is considered irrelevant if it's a fork or if it has no metadata (no description, no icon, no topic).
+;ONLY_SHOW_RELEVANT_REPOS = false
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1131,7 +1189,7 @@ DEFAULT_THEME = gitea
 ;;
 ;; Control how often the notification endpoint is polled to update the notification
 ;; The timeout will increase to MAX_TIMEOUT in TIMEOUT_STEPs if the notification count is unchanged
-;; Set MIN_TIMEOUT to 0 to turn off
+;; Set MIN_TIMEOUT to -1 to turn off
 ;MIN_TIMEOUT = 10s
 ;MAX_TIMEOUT = 60s
 ;TIMEOUT_STEP = 10s
@@ -1181,6 +1239,9 @@ DEFAULT_THEME = gitea
 ;; List of file extensions that should be rendered/edited as Markdown
 ;; Separate the extensions with a comma. To render files without any extension as markdown, just put a comma
 ;FILE_EXTENSIONS = .md,.markdown,.mdown,.mkd
+;;
+;; Enables math inline and block detection
+;ENABLE_MATH = true
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1191,7 +1252,7 @@ DEFAULT_THEME = gitea
 ;; Define allowed algorithms and their minimum key length (use -1 to disable a type)
 ;ED25519 = 256
 ;ECDSA = 256
-;RSA = 2048
+;RSA = 2047 ; we allow 2047 here because an otherwise valid 2048 bit RSA key can be reported as having 2047 bit length
 ;DSA = -1 ; set to 1024 to switch on
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1216,7 +1277,7 @@ DEFAULT_THEME = gitea
 ;ISSUE_INDEXER_NAME = gitea_issues
 ;;
 ;; Timeout the indexer if it takes longer than this to start.
-;; Set to zero to disable timeout.
+;; Set to -1 to disable timeout.
 ;STARTUP_TIMEOUT = 30s
 ;;
 ;; Issue indexer queue, currently support: channel, levelqueue or redis, default is levelqueue (deprecated - use [queue.issue_indexer])
@@ -1243,10 +1304,10 @@ DEFAULT_THEME = gitea
 REPO_INDEXER_ENABLED = {{ 'true' if gitea_repo_indexer_enabled else 'false' }}
 ;;
 ;; Code search engine type, could be `bleve` or `elasticsearch`.
-REPO_INDEXER_TYPE = bleve
+;REPO_INDEXER_TYPE = bleve
 ;;
 ;; Index file used for code search. available when `REPO_INDEXER_TYPE` is bleve
-REPO_INDEXER_PATH = indexers/repos.bleve
+;REPO_INDEXER_PATH = indexers/repos.bleve
 ;;
 ;; Code indexer connection string, available when `REPO_INDEXER_TYPE` is elasticsearch. i.e. http://elastic:changeme@localhost:9200
 ;REPO_INDEXER_CONN_STR =
@@ -1256,7 +1317,7 @@ REPO_INDEXER_PATH = indexers/repos.bleve
 ;;
 ;; A comma separated list of glob patterns (see https://github.com/gobwas/glob) to include
 ;; in the index; default is empty
-REPO_INDEXER_INCLUDE =
+;REPO_INDEXER_INCLUDE =
 ;;
 ;; A comma separated list of glob patterns to exclude from the index; ; default is empty
 {% if gitea_repo_indexer_exclude %}
@@ -1267,8 +1328,7 @@ REPO_INDEXER_EXCLUDE = {{ gitea_repo_indexer_exclude|join(', ') }}
 ;;
 ;;
 ;UPDATE_BUFFER_LEN = 20; **DEPRECATED** use settings in `[queue.issue_indexer]`.
-; Skip indexing of all files larger than the specified value
-MAX_FILE_SIZE = 1048576
+;MAX_FILE_SIZE = 1048576
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1449,9 +1509,14 @@ ALLOWED_HOST_LIST = {{ gitea_webhook_allowed_hosts|join(', ') }}
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;[mailer]
+[mailer]
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; NOTICE: this section is for Gitea 1.18 and later. If you are using Gitea 1.17 or older,
+;; please refer to
+;; https://github.com/go-gitea/gitea/blob/release/v1.17/custom/conf/app.example.ini
+;; https://github.com/go-gitea/gitea/blob/release/v1.17/docs/content/doc/advanced/config-cheat-sheet.en-us.md
 ;;
 ENABLED = {{ gitea_mailer_enabled }}
 ;;
@@ -1462,30 +1527,46 @@ ENABLED = {{ gitea_mailer_enabled }}
 ;; Prefix displayed before subject in mail
 ;SUBJECT_PREFIX =
 ;;
-;; Mail server
-;; Gmail: smtp.gmail.com:587
-;; QQ: smtp.qq.com:465
-;; As per RFC 8314 using Implicit TLS/SMTPS on port 465 (if supported) is recommended,
-;; otherwise STARTTLS on port 587 should be used.
-HOST = {{ gitea_mail_host }}
+;; Mail server protocol. One of "smtp", "smtps", "smtp+starttls", "smtp+unix", "sendmail", "dummy".
+;; - sendmail: use the operating system's `sendmail` command instead of SMTP. This is common on Linux systems.
+;; - dummy: send email messages to the log as a testing phase.
+;; If your provider does not explicitly say which protocol it uses but does provide a port,
+;; you can set SMTP_PORT instead and this will be inferred.
+;; (Before 1.18, see the notice, this was controlled via MAILER_TYPE and IS_TLS_ENABLED.)
+PROTOCOL = {{ gitea_mail_protocol }}
 ;;
-;; Disable HELO operation when hostnames are different.
-;DISABLE_HELO =
+;; Mail server address, e.g. smtp.gmail.com.
+;; For smtp+unix, this should be a path to a unix socket instead.
+;; (Before 1.18, see the notice, this was combined with SMTP_PORT as HOST.)
+{% if gitea_mail_smtp_addr is defined %}
+SMTP_ADDR = {{ gitea_mail_smtp_addr }}
+{% endif %}
 ;;
-;; Custom hostname for HELO operation, if no value is provided, one is retrieved from system.
+;; Mail server port. Common ports are:
+;;   25:  insecure SMTP
+;;   465: SMTP Secure
+;;   587: StartTLS
+;; If no protocol is specified, it will be inferred by this setting.
+;; (Before 1.18, this was combined with SMTP_ADDR as HOST.)
+{% if gitea_mail_smtp_port is defined %}
+SMTP_PORT = {{ gitea_mail_smtp_port }}
+{% endif %}
+;;
+;; Enable HELO operation. Defaults to true.
+;ENABLE_HELO = true
+;;
+;; Custom hostname for HELO operation.
+;; If no value is provided, one is retrieved from system.
 ;HELO_HOSTNAME =
 ;;
-;; Whether or not to skip verification of certificates; `true` to disable verification. This option is unsafe. Consider adding the certificate to the system trust store instead.
-;SKIP_VERIFY = false
+;; If set to `true`, completely ignores server certificate validation errors.
+;; This option is unsafe. Consider adding the certificate to the system trust store instead.
+;FORCE_TRUST_SERVER_CERT = false
 ;;
-;; Use client certificate
-;USE_CERTIFICATE = false
-;CERT_FILE = custom/mailer/cert.pem
-;KEY_FILE = custom/mailer/key.pem
-;;
-;; Should SMTP connect with TLS, (if port ends with 465 TLS will always be used.)
-;; If this is false but STARTTLS is supported the connection will be upgraded to TLS opportunistically.
-;IS_TLS_ENABLED = false
+;; Use client certificate in connection.
+;USE_CLIENT_CERT = false
+;CLIENT_CERT_FILE = custom/mailer/cert.pem
+;CLIENT_KEY_FILE = custom/mailer/key.pem
 ;;
 ;; Mail from address, RFC 5322. This can be just an email address, or the `"Name" <email@example.com>` format
 FROM = {{ gitea_mail_from }}
@@ -1493,23 +1574,20 @@ FROM = {{ gitea_mail_from }}
 ;; Sometimes it is helpful to use a different address on the envelope. Set this to use ENVELOPE_FROM as the from on the envelope. Set to `<>` to send an empty address.
 ;ENVELOPE_FROM =
 ;;
-;; Mailer user name and password
-;; Please Note: Authentication is only supported when the SMTP server communication is encrypted with TLS (this can be via STARTTLS) or `HOST=localhost`.
+;; Mailer user name and password, if required by provider.
 USER = {{ gitea_mail_user }}
 ;;
 ;; Use PASSWD = `your password` for quoting if you use special characters in the password.
 PASSWD = {{ gitea_mail_password }}
 ;;
-;; Send mails as plain text
+;; Send mails only in plain text, without HTML alternative
 ;SEND_AS_PLAIN_TEXT = false
-;;
-;; Set Mailer Type (either SMTP, sendmail or dummy to just send to the log)
-;MAILER_TYPE = smtp
 ;;
 ;; Specify an alternative sendmail binary
 ;SENDMAIL_PATH = sendmail
 ;;
 ;; Specify any extra sendmail arguments
+;; WARNING: if your sendmail program interprets options you should set this to "--" or terminate these args with "--"
 ;SENDMAIL_ARGS =
 ;;
 ;; Timeout for Sendmail
@@ -1541,7 +1619,7 @@ PASSWD = {{ gitea_mail_password }}
 ;HOST =
 ;;
 ;; Time to keep items in cache if not used, default is 16 hours.
-;; Setting it to 0 disables caching
+;; Setting it to -1 disables caching
 ;ITEM_TTL = 16h
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1555,7 +1633,7 @@ PASSWD = {{ gitea_mail_password }}
 ;ENABLED = true
 ;;
 ;; Time to keep items in cache if not used, default is 8760 hours.
-;; Setting it to 0 disables caching
+;; Setting it to -1 disables caching
 ;ITEM_TTL = 8760h
 ;;
 ;; Only enable the cache when repository's commits count great than
@@ -1567,7 +1645,8 @@ PASSWD = {{ gitea_mail_password }}
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
-;; Either "memory", "file", or "redis", default is "memory"
+;; Either "memory", "file", "redis", "db", "mysql", "couchbase", "memcache" or "postgres"
+;; Default is "memory". "db" will reuse the configuration in [database]
 ;PROVIDER = memory
 ;;
 ;; Provider config options
@@ -1641,7 +1720,7 @@ DISABLE_GRAVATAR = {{ gitea_disable_gravatar }}
 ;ENABLED = true
 ;;
 ;; Comma-separated list of allowed file extensions (`.zip`), mime types (`text/plain`) or wildcard type (`image/*`, `audio/*`, `video/*`). Empty value or `*/*` allows all types.
-;ALLOWED_TYPES = .docx,.gif,.gz,.jpeg,.jpg,.mp4,.log,.pdf,.png,.pptx,.txt,.xlsx,.zip
+;ALLOWED_TYPES = .csv,.docx,.fodg,.fodp,.fods,.fodt,.gif,.gz,.jpeg,.jpg,.log,.md,.mov,.mp4,.odf,.odg,.odp,.ods,.odt,.pdf,.png,.pptx,.svg,.tgz,.txt,.webm,.xls,.xlsx,.zip
 ;;
 ;; Max size of each file. Defaults to 4MB
 ;MAX_SIZE = 4
@@ -1729,8 +1808,8 @@ DISABLE_GRAVATAR = {{ gitea_disable_gravatar }}
 ;ENABLED = true
 ;; Whether to always run at least once at start up time (if ENABLED)
 ;RUN_AT_START = true
-;; Notice if not success
-;NO_SUCCESS_NOTICE = false
+;; Whether to emit notice on successful execution too
+;NOTICE_ON_SUCCESS = false
 ;; Time interval for job to run
 ;SCHEDULE = @midnight
 ;; Archives created more than OLDER_THAN ago are subject to deletion
@@ -1749,7 +1828,7 @@ DISABLE_GRAVATAR = {{ gitea_disable_gravatar }}
 ;; Run Update mirrors task when Gitea starts.
 ;RUN_AT_START = false
 ;; Notice if not success
-;NO_SUCCESS_NOTICE = true
+;NOTICE_ON_SUCCESS = false
 ;; Limit the number of mirrors added to the queue to this number
 ;; (negative values mean no limit, 0 will result in no result in no mirrors being queued effectively disabling pull mirror updating.)
 ;PULL_LIMIT=50
@@ -1770,7 +1849,7 @@ DISABLE_GRAVATAR = {{ gitea_disable_gravatar }}
 ;; Run Repository health check task when Gitea starts.
 ;RUN_AT_START = false
 ;; Notice if not success
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;TIMEOUT = 60s
 ;; Arguments for command 'git fsck', e.g. "--unreachable --tags"
 ;; see more on http://git-scm.com/docs/git-fsck
@@ -1788,7 +1867,7 @@ DISABLE_GRAVATAR = {{ gitea_disable_gravatar }}
 ;; Run check repository statistics task when Gitea starts.
 ;RUN_AT_START = true
 ;; Notice if not success
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;SCHEDULE = @midnight
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1801,7 +1880,7 @@ DISABLE_GRAVATAR = {{ gitea_disable_gravatar }}
 ;; Update migrated repositories' issues and comments' posterid when starting server (default true)
 ;RUN_AT_START = true
 ;; Notice if not success
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;; Interval as a duration between each synchronization. (default every 24h)
 ;SCHEDULE = @midnight
 
@@ -1816,7 +1895,7 @@ DISABLE_GRAVATAR = {{ gitea_disable_gravatar }}
 ;; Synchronize external user data when starting server (default false)
 ;RUN_AT_START = false
 ;; Notice if not success
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;; Interval as a duration between each synchronization (default every 24h)
 ;SCHEDULE = @midnight
 ;; Create new users, update existing user data and disable users that are not in external source anymore (default)
@@ -1834,7 +1913,7 @@ DISABLE_GRAVATAR = {{ gitea_disable_gravatar }}
 ;; Clean-up deleted branches when starting server (default true)
 ;RUN_AT_START = true
 ;; Notice if not success
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;; Interval as a duration between each synchronization (default every 24h)
 ;SCHEDULE = @midnight
 ;; deleted branches than OLDER_THAN ago are subject to deletion
@@ -1862,6 +1941,24 @@ DISABLE_GRAVATAR = {{ gitea_disable_gravatar }}
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Cleanup expired packages
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[cron.cleanup_packages]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Whether to enable the job
+;ENABLED = true
+;; Whether to always run at least once at start up time (if ENABLED)
+;RUN_AT_START = true
+;; Whether to emit notice on successful execution too
+;NOTICE_ON_SUCCESS = false
+;; Time interval for job to run
+;SCHEDULE = @midnight
+;; Unreferenced blobs created more than OLDER_THAN ago are subject to deletion
+;OLDER_THAN = 24h
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Extended cron task - not enabled by default
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1877,7 +1974,7 @@ DISABLE_GRAVATAR = {{ gitea_disable_gravatar }}
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;ENABLED = false
 ;RUN_AT_START = false
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;SCHEDULE = @annually
 ;OLDER_THAN = 168h
 
@@ -1890,7 +1987,7 @@ DISABLE_GRAVATAR = {{ gitea_disable_gravatar }}
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;ENABLED = false
 ;RUN_AT_START = false
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;SCHEDULE = @annually;
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1902,7 +1999,7 @@ DISABLE_GRAVATAR = {{ gitea_disable_gravatar }}
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;ENABLED = false
 ;RUN_AT_START = false
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;SCHEDULE = @every 72h
 ;TIMEOUT = 60s
 ;; Arguments for command 'git gc'
@@ -1918,7 +2015,7 @@ DISABLE_GRAVATAR = {{ gitea_disable_gravatar }}
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;ENABLED = false
 ;RUN_AT_START = false
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;SCHEDULE = @every 72h
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1930,7 +2027,7 @@ DISABLE_GRAVATAR = {{ gitea_disable_gravatar }}
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;ENABLED = false
 ;RUN_AT_START = false
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;SCHEDULE = @every 72h
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1942,7 +2039,7 @@ DISABLE_GRAVATAR = {{ gitea_disable_gravatar }}
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;ENABLED = false
 ;RUN_AT_START = false
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;SCHEDULE = @every 72h
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1954,7 +2051,7 @@ DISABLE_GRAVATAR = {{ gitea_disable_gravatar }}
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;ENABLED = false
 ;RUN_AT_START = false
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;SCHEDULE = @every 72h
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1966,7 +2063,7 @@ DISABLE_GRAVATAR = {{ gitea_disable_gravatar }}
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;ENABLED = false
 ;RUN_AT_START = false
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;SCHEDULE = @every 72h
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -1978,7 +2075,7 @@ DISABLE_GRAVATAR = {{ gitea_disable_gravatar }}
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;ENABLED = false
 ;RUN_AT_START = false
-;NO_SUCCESS_NOTICE = false
+;NOTICE_ON_SUCCESS = false
 ;SCHEDULE = @every 168h
 ;OLDER_THAN = 8760h
 
@@ -1994,6 +2091,19 @@ DISABLE_GRAVATAR = {{ gitea_disable_gravatar }}
 ;ENABLE_SUCCESS_NOTICE = false
 ;SCHEDULE = @every 168h
 ;HTTP_ENDPOINT = https://dl.gitea.io/gitea/version.json
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Delete all old system notices from database
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[cron.delete_old_system_notices]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;ENABLED = false
+;RUN_AT_START = false
+;NO_SUCCESS_NOTICE = false
+;SCHEDULE = @every 168h
+;OLDER_THAN = 8760h
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2014,7 +2124,7 @@ DISABLE_GRAVATAR = {{ gitea_disable_gravatar }}
 ;[mirror]
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Enables the mirror functionality. Set to **false** to disable all mirrors.
+;; Enables the mirror functionality. Set to **false** to disable all mirrors. Pre-existing mirrors remain valid but won't be updated; may be converted to regular repo.
 ;ENABLED = true
 ;; Disable the creation of **new** pull mirrors. Pre-existing mirrors remain valid. Will be ignored if `mirror.ENABLED` is `false`.
 ;DISABLE_NEW_PULL = false
@@ -2027,18 +2137,18 @@ DISABLE_GRAVATAR = {{ gitea_disable_gravatar }}
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-[api]
+;[api]
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Enables Swagger. True or false; default is true.
-ENABLE_SWAGGER = {{ gitea_enable_api }}
+;; Enables the API documentation endpoints (/api/swagger, /api/v1/swagger, …). True or false.
+;ENABLE_SWAGGER = true
 ;; Max number of items in a page
-MAX_RESPONSE_ITEMS = {{ gitea_api_max_results }}
+;MAX_RESPONSE_ITEMS = 50
 ;; Default paging number of api
 ;DEFAULT_PAGING_NUM = 30
 ;; Default and maximum number of items per page for git trees api
 ;DEFAULT_GIT_TREES_PER_PAGE = 1000
-;; Default size of a blob returned by the blobs API (default is 10MiB)
+;; Default max size of a blob returned by the blobs API (default is 10MiB)
 ;DEFAULT_MAX_BLOB_SIZE = 10485760
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2046,8 +2156,9 @@ MAX_RESPONSE_ITEMS = {{ gitea_api_max_results }}
 ;[i18n]
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;LANGS = en-US,zh-CN,zh-HK,zh-TW,de-DE,fr-FR,nl-NL,lv-LV,ru-RU,uk-UA,ja-JP,es-ES,pt-BR,pt-PT,pl-PL,bg-BG,it-IT,fi-FI,tr-TR,cs-CZ,sr-SP,sv-SE,ko-KR,el-GR,fa-IR,hu-HU,id-ID,ml-IN
-;NAMES = English,简体中文,繁體中文（香港）,繁體中文（台灣）,Deutsch,français,Nederlands,latviešu,русский,Українська,日本語,español,português do Brasil,Português de Portugal,polski,български,italiano,suomi,Türkçe,čeština,српски,svenska,한국어,ελληνικά,فارسی,magyar nyelv,bahasa Indonesia,മലയാളം
+;; The first locale will be used as the default if user browser's language doesn't match any locale in the list.
+;LANGS = en-US,zh-CN,zh-HK,zh-TW,de-DE,fr-FR,nl-NL,lv-LV,ru-RU,uk-UA,ja-JP,es-ES,pt-BR,pt-PT,pl-PL,bg-BG,it-IT,fi-FI,tr-TR,cs-CZ,sv-SE,ko-KR,el-GR,fa-IR,hu-HU,id-ID,ml-IN
+;NAMES = English,简体中文,繁體中文（香港）,繁體中文（台灣）,Deutsch,Français,Nederlands,Latviešu,Русский,Українська,日本語,Español,Português do Brasil,Português de Portugal,Polski,Български,Italiano,Suomi,Türkçe,Čeština,Српски,Svenska,한국어,Ελληνικά,فارسی,Magyar nyelv,Bahasa Indonesia,മലയാളം
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2059,7 +2170,7 @@ MAX_RESPONSE_ITEMS = {{ gitea_api_max_results }}
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-[other]
+;[other]
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;SHOW_FOOTER_BRANDING = false
@@ -2103,6 +2214,11 @@ MAX_RESPONSE_ITEMS = {{ gitea_api_max_results }}
 ;RENDER_COMMAND = "asciidoc --out-file=- -"
 ;; Don't pass the file on STDIN, pass the filename as argument instead.
 ;IS_INPUT_FILE = false
+;; How the content will be rendered.
+;; * sanitized: Sanitize the content and render it inside current page, default to only allow a few HTML tags and attributes. Customized sanitizer rules can be defined in [markup.sanitizer.*] .
+;; * no-sanitizer: Disable the sanitizer and render the content inside current page. It's **insecure** and may lead to XSS attack if the content contains malicious code.
+;; * iframe: Render the content in a separate standalone page and embed it into current page by iframe. The iframe is in sandbox mode with same-origin disabled, and the JS code are safely isolated from parent page.
+;RENDER_CONTENT_MODE=sanitized
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2148,13 +2264,16 @@ MAX_RESPONSE_ITEMS = {{ gitea_api_max_results }}
 ;;
 ;; Allowed domains for migrating, default is blank. Blank means everything will be allowed.
 ;; Multiple domains could be separated by commas.
+;; Wildcard is supported: "github.com, *.github.com"
 ;ALLOWED_DOMAINS =
 ;;
 ;; Blocklist for migrating, default is blank. Multiple domains could be separated by commas.
 ;; When ALLOWED_DOMAINS is not blank, this option has a higher priority to deny domains.
+;; Wildcard is supported.
 ;BLOCKED_DOMAINS =
 ;;
 ;; Allow private addresses defined by RFC 1918, RFC 1122, RFC 4632 and RFC 4291 (false by default)
+;; If a domain is allowed by ALLOWED_DOMAINS, this option will be ignored.
 ;ALLOW_LOCALNETWORKS = false
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2164,7 +2283,39 @@ MAX_RESPONSE_ITEMS = {{ gitea_api_max_results }}
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; Enable/Disable federation capabilities
-; ENABLED = true
+;ENABLED = false
+;;
+;; Enable/Disable user statistics for nodeinfo if federation is enabled
+;SHARE_USER_STATISTICS = true
+;;
+;; Maximum federation request and response size (MB)
+;MAX_SIZE = 4
+;;
+;; WARNING: Changing the settings below can break federation.
+;;
+;; HTTP signature algorithms
+;ALGORITHMS = rsa-sha256, rsa-sha512, ed25519
+;;
+;; HTTP signature digest algorithm
+;DIGEST_ALGORITHM = SHA-256
+;;
+;; GET headers for federation requests
+;GET_HEADERS = (request-target), Date
+;;
+;; POST headers for federation requests
+;POST_HEADERS = (request-target), Date, Digest
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[packages]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Enable/Disable package registry capabilities
+;ENABLED = true
+;;
+;; Path for chunked uploads. Defaults to APP_DATA_PATH + `tmp/package-upload`
+;CHUNKED_UPLOAD_PATH = tmp/package-upload
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2195,6 +2346,16 @@ MAX_RESPONSE_ITEMS = {{ gitea_api_max_results }}
 ;;
 ;; Where your lfs files reside, default is data/lfs.
 ;PATH = data/lfs
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; settings for packages, will override storage setting
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;[storage.packages]
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; storage type
+;STORAGE_TYPE = local
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/roles/gitea/templates/etc_gitea_app.ini
+++ b/roles/gitea/templates/etc_gitea_app.ini
@@ -12,7 +12,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;
 ;; App name that shows in every page title
-APP_NAME = Gitea; Git with a cup of tea
+APP_NAME = Gitea
 ;;
 ;; RUN_USER will automatically detect the current user - but you can set it here change it if you run locally
 RUN_USER = gitea
@@ -45,7 +45,7 @@ RUN_MODE = prod
 ;DOMAIN = localhost
 ;;
 ;; Overwrite the automatically generated public URL. Necessary for proxies and docker.
-ROOT_URL = {{ gitea_root_url }};%(PROTOCOL)s://%(DOMAIN)s:%(HTTP_PORT)s/
+ROOT_URL = {{ gitea_root_url }}
 ;;
 ;; when STATIC_URL_PREFIX is empty it will follow ROOT_URL
 ;STATIC_URL_PREFIX =
@@ -106,7 +106,7 @@ HTTP_PORT = 3003
 ;BUILTIN_SSH_SERVER_USER = %(RUN_USER)s
 ;;
 ;; Domain name to be exposed in clone URL
-SSH_DOMAIN = {{ gitea_fqdn }}; %(DOMAIN)s
+SSH_DOMAIN = {{ gitea_fqdn }}
 ;;
 ;; SSH username displayed in clone URLs.
 ;SSH_USER = %(BUILTIN_SSH_SERVER_USER)s
@@ -824,16 +824,16 @@ ROOT = {{ gitea_user_home }}/repos/
 ;ANSI_CHARSET =
 ;;
 ;; Force every new repository to be private
-;FORCE_PRIVATE = false
+FORCE_PRIVATE = {{ gitea_force_private }}
 ;;
 ;; Default privacy setting when creating a new repository, allowed values: last, private, public. Default is last which means the last setting used.
-;DEFAULT_PRIVATE = last
+DEFAULT_PRIVATE = {{ gitea_default_private }}
 ;;
 ;; Default private when using push-to-create
 ;DEFAULT_PUSH_CREATE_PRIVATE = true
 ;;
 ;; Global limit of repositories per user, applied at creation time. -1 means no limit
-;MAX_CREATION_LIMIT = -1
+MAX_CREATION_LIMIT = {{ gitea_user_repo_limit }}
 ;;
 ;; Mirror sync queue length, increase if mirror syncing starts hanging (DEPRECATED: please use [queue.mirror] LENGTH instead)
 ;MIRROR_QUEUE_LENGTH = 1000
@@ -2141,9 +2141,9 @@ DISABLE_GRAVATAR = {{ gitea_disable_gravatar }}
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Enables the API documentation endpoints (/api/swagger, /api/v1/swagger, …). True or false.
-;ENABLE_SWAGGER = true
+ENABLE_SWAGGER = {{ gitea_enable_api }}
 ;; Max number of items in a page
-;MAX_RESPONSE_ITEMS = 50
+MAX_RESPONSE_ITEMS = {{ gitea_api_max_results }}
 ;; Default paging number of api
 ;DEFAULT_PAGING_NUM = 30
 ;; Default and maximum number of items per page for git trees api

--- a/roles/gitea/templates/etc_gitea_app.ini
+++ b/roles/gitea/templates/etc_gitea_app.ini
@@ -1548,8 +1548,8 @@ SMTP_ADDR = {{ gitea_mail_host }}
 ;;   587: StartTLS
 ;; If no protocol is specified, it will be inferred by this setting.
 ;; (Before 1.18, this was combined with SMTP_ADDR as HOST.)
-{% if gitea_mail_host is defined %}
-SMTP_PORT = {{ gitea_mail_host }}
+{% if gitea_mail_port is defined %}
+SMTP_PORT = {{ gitea_mail_port }}
 {% endif %}
 ;;
 ;; Enable HELO operation. Defaults to true.

--- a/roles/gitea/templates/etc_gitea_app.ini
+++ b/roles/gitea/templates/etc_gitea_app.ini
@@ -1538,8 +1538,8 @@ PROTOCOL = {{ gitea_mail_protocol }}
 ;; Mail server address, e.g. smtp.gmail.com.
 ;; For smtp+unix, this should be a path to a unix socket instead.
 ;; (Before 1.18, see the notice, this was combined with SMTP_PORT as HOST.)
-{% if gitea_mail_smtp_addr is defined %}
-SMTP_ADDR = {{ gitea_mail_smtp_addr }}
+{% if gitea_mail_host is defined %}
+SMTP_ADDR = {{ gitea_mail_host }}
 {% endif %}
 ;;
 ;; Mail server port. Common ports are:
@@ -1548,8 +1548,8 @@ SMTP_ADDR = {{ gitea_mail_smtp_addr }}
 ;;   587: StartTLS
 ;; If no protocol is specified, it will be inferred by this setting.
 ;; (Before 1.18, this was combined with SMTP_ADDR as HOST.)
-{% if gitea_mail_smtp_port is defined %}
-SMTP_PORT = {{ gitea_mail_smtp_port }}
+{% if gitea_mail_host is defined %}
+SMTP_PORT = {{ gitea_mail_host }}
 {% endif %}
 ;;
 ;; Enable HELO operation. Defaults to true.


### PR DESCRIPTION
Monté de version de Gitea en 1.18.0

Pour le fichier _<roles/gitea/templates/etc_gitea_app.ini>_ je suis parti du fichier https://github.com/go-gitea/gitea/blob/v1.18.0/custom/conf/app.example.ini dans lequel j'ai poussé la conf existante.

