### PR TITLE
fix(gitea): StartLimitIntervalSec key should be in "unit" section

### DIFF
--- a/roles/gitea/templates/etc_systemd_system_gitea.service.j2
+++ b/roles/gitea/templates/etc_systemd_system_gitea.service.j2
@@ -4,6 +4,8 @@
 Description=Gitea git service
 After=syslog.target
 After=network.target
+StartLimitIntervalSec=10s
+StartLimitBurst=4
 ###
 # Don't forget to add the database service requirements
 ###
@@ -49,8 +51,6 @@ After=redis.service
 #LimitMEMLOCK=infinity
 #LimitNOFILE=65535
 RestartSec=2s
-StartLimitIntervalSec=10s
-StartLimitBurst=4
 Type=simple
 User=gitea
 Group=gitea


### PR DESCRIPTION
"StartLimitBurst" too.

See: https://manpages.debian.org/bullseye/systemd/systemd.unit.5.en.html